### PR TITLE
[SDXL-IP2P] Update README_sdxl, Replace the link for wandb log with the correct run

### DIFF
--- a/examples/instruct_pix2pix/README_sdxl.md
+++ b/examples/instruct_pix2pix/README_sdxl.md
@@ -71,7 +71,7 @@ accelerate launch train_instruct_pix2pix_sdxl.py \
 
  We recommend this type of validation as it can be useful for model debugging. Note that you need `wandb` installed to use this. You can install `wandb` by running `pip install wandb`. 
 
- [Here](https://wandb.ai/sayakpaul/instruct-pix2pix/runs/ctr3kovq), you can find an example training run that includes some validation samples and the training hyperparameters.
+ [Here](https://wandb.ai/sayakpaul/instruct-pix2pix-sdxl-new/runs/sw53gxmc), you can find an example training run that includes some validation samples and the training hyperparameters.
 
  ***Note: In the original paper, the authors observed that even when the model is trained with an image resolution of 256x256, it generalizes well to bigger resolutions such as 512x512. This is likely because of the larger dataset they used during training.***
 


### PR DESCRIPTION
## What does this PR do?

It just replaces the wandb run with the correct link in `README_sdxl.md` for instructpix2pix training. The new link for wandb run is from the [diffusers/sdxl-instructpix2pix-768](https://huggingface.co/diffusers/sdxl-instructpix2pix-768) model page. (The old one was pointing to SD1.5 instructpix2pix run)
## 
I think there is a typo in the model page as well. It says that batch size per GPU is 8 (x4 gradient accumulation=32) but in the wandb run, I see that it's actually 4 (x4 gradient accumulation=16).

Besides, I observe that some of the parameters are different from the script on `README_sdxl`. For example the `diffusers/sdxl-instructpix2pix-768` model is trained with `learning_rate=5e-06` and `conditioning_dropout_prob=0.1` whereas the script defaults are `5e-05` and `0.05`. Apparently hyperparameters differs from [SD1.5 IP2P training](wandb.ai/sayakpaul/instruct-pix2pix/runs/ctr3kovq/overview), so it might be useful to change those defaults for SDXL so that we would know which set of hyperparameters worked out well for SDXL case.
Maybe @harutatsuakiyama also have some insights here about the hyperparams working the best.


cc: @sayakpaul